### PR TITLE
try to ensure the first line of exception string is not empty

### DIFF
--- a/lib/Exception/Class/Base.pm
+++ b/lib/Exception/Class/Base.pm
@@ -169,6 +169,11 @@ sub as_string {
     my $self = shift;
 
     my $str = $self->full_message;
+    unless (defined $str and length $str) {
+        my $desc = $self->description;
+        $str = defined $desc && length $desc ? "[$desc]" : "[Generic exception]";
+    }
+
     $str .= "\n\n" . $self->trace->as_string
         if $self->show_trace;
 


### PR DESCRIPTION
If a user does `Error::Class->throw` with no error, the stringified form starts with a blank line.  This can lead to horrible logs, pulled hair, and a deep loathing of life.
