### PR TITLE
Set %INC for generated classes

### DIFF
--- a/lib/Exception/Class.pm
+++ b/lib/Exception/Class.pm
@@ -188,6 +188,9 @@ EOPERL
     eval $code;
     die $@ if $@;
 
+    ( my $filename = "$subclass.pm" ) =~ s{::}{/}g;
+    $INC{$filename} = __FILE__;
+
     $CLASSES{$subclass} = 1;
 }
 

--- a/perlcriticrc
+++ b/perlcriticrc
@@ -65,3 +65,6 @@ add_packages = Carp Test::Builder
 # prevents very common errors when using a sub in list context to construct a
 # hash and ending up with a missing value or key.
 [-Subroutines::ProhibitExplicitReturnUndef]
+
+[Variables::RequireLocalizedPunctuationVars]
+allow = %INC


### PR DESCRIPTION
This patch will avoid base.pm trying to autoload this class when it's not necessary.