### PR TITLE
Fix module to work with Perl 5.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ perl:
   - '5.12'
   - '5.10'
   - '5.8'
+  - '5.6.2'
 matrix:
   allow_failures:
     - perl: blead
@@ -29,4 +30,6 @@ env:
     - RELEASE_TESTING=1
     - AUTHOR_TESTING=1
 before_install:
+  - if [ "$TRAVIS_PERL_VERSION" = "5.6.2" ]; then rm -f dist.ini; fi # Force Building with Makefile.PL on Perl 5.6.2 as dzil would not work
   - eval $(curl https://travis-perl.github.io/init) --auto
+  - if [ "$TRAVIS_PERL_VERSION" = "5.6.2" ]; then cpan Devel::StackTrace; fi

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use 5.008001;
+use 5.006;
 
 use ExtUtils::MakeMaker;
 
@@ -14,7 +14,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "Exception-Class",
   "LICENSE" => "perl",
-  "MIN_PERL_VERSION" => "5.008001",
+  "MIN_PERL_VERSION" => "5.006",
   "NAME" => "Exception::Class",
   "PREREQ_PM" => {
     "Class::Data::Inheritable" => "0.02",

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@ requires "Devel::StackTrace" => "2.00";
 requires "Scalar::Util" => "0";
 requires "base" => "0";
 requires "overload" => "0";
-requires "perl" => "5.008001";
+requires "perl" => "5.006";
 requires "strict" => "0";
 requires "warnings" => "0";
 

--- a/lib/Exception/Class.pm
+++ b/lib/Exception/Class.pm
@@ -1,6 +1,6 @@
 package Exception::Class;
 
-use 5.008001;
+use 5.006;
 
 use strict;
 use warnings;


### PR DESCRIPTION
With Perl 5.6.2 and Test::More 0.96 all tests passes. But this version is
not available on CPAN anymore (only on BackPAN). Test::More version
available in Perl 5.6.2 does not support done_testing, so use no_plan.