### PR TITLE
Make full_message() call message() method for better subclassing

### DIFF
--- a/lib/Exception/Class/Base.pm
+++ b/lib/Exception/Class/Base.pm
@@ -219,7 +219,7 @@ sub as_string {
     return $str;
 }
 
-sub full_message { $_[0]->{message} }
+sub full_message { $_[0]->message }
 
 #
 # The %seen bit protects against circular inheritance.


### PR DESCRIPTION
Tests looks ok
```
t/basic.t ........... ok
t/caught.t .......... ok
t/context.t ......... ok
t/ecb-standalone.t .. ok
t/ignore.t .......... ok
All tests successful.
Files=5, Tests=75,  1 wallclock secs ( 0.05 usr  0.03 sys +  0.21 cusr  0.04 csys =  0.33 CPU)
Result: PASS
```