### PR TITLE
Check field names before creating named subs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ my %WriteMakefileArgs = (
   "MIN_PERL_VERSION" => "5.008001",
   "NAME" => "Exception::Class",
   "PREREQ_PM" => {
+    "Carp" => "0",
     "Class::Data::Inheritable" => "0.02",
     "Devel::StackTrace" => "2.00",
     "Scalar::Util" => 0,

--- a/lib/Exception/Class.pm
+++ b/lib/Exception/Class.pm
@@ -8,6 +8,7 @@ use warnings;
 our $VERSION = '1.45';
 
 use Exception::Class::Base;
+use Carp qw(croak);
 use Scalar::Util qw( blessed reftype );
 
 our $BASE_EXC_CLASS;
@@ -161,6 +162,9 @@ EOPERL
             . ") }\n\n";
 
         foreach my $field (@fields) {
+            croak
+                "Invalid field name <$field>. A field name must be a legal Perl identifier."
+                unless $field =~ /\A[a-z_][a-z0-9_]*\z/i;
             $code .= sprintf( "sub %s { \$_[0]->{%s} }\n", $field, $field );
         }
     }

--- a/lib/Exception/Class.pm
+++ b/lib/Exception/Class.pm
@@ -354,6 +354,11 @@ an accessor method for the fields you define.
 This parameter can be either a scalar (for a single field) or an array
 reference if you need to define multiple fields.
 
+Each field name must be a legal Perl identifier: it starts with a ASCII letter
+or underscore, and is followed by zero or more ASCII letters, ASCII digits, or
+underscores. If a field name does not match this, the creation of that exception
+class croaks.
+
 Fields will be inherited by subclasses.
 
 =item * alias

--- a/t/field-names.t
+++ b/t/field-names.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+use File::Spec;
+
+use Test::More 0.88;
+
+require_ok('Exception::Class');
+
+# no problems here
+{
+    my $rc = eval {
+        Exception::Class->import(
+            'GoodFields' => { fields => [qw( foo )] },
+        );
+        'success';
+    };
+    is( $rc, 'success', 'GoodFields did not have a problem' );
+}
+
+# problems here
+
+my @bad_fields = ( '$foo', q(f'oo), 'f oo' );
+
+my $n = 0;
+foreach my $bad_field (@bad_fields) {
+    $n++;
+    my $rc = eval {
+        Exception::Class->import(
+            "GoodFields$n" => { fields => [$bad_field] },
+        );
+        q(we should not get this far);
+    };
+    my $error = $@;
+    ok( !defined $rc, "Field name <$bad_field> throws an error" );
+    like $error, qr/Invalid field name/,
+        'Error messages notes invalid field name';
+}
+
+done_testing();


### PR DESCRIPTION
values for `fields` must now be Perl identifiers.

Note that after running `tidyall -a`, several other files were modified. I did not include them in this patch.